### PR TITLE
Add: Note about updating policy for large installs

### DIFF
--- a/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
+++ b/guide/installation-and-configuration/general-installation/installation-enterprise.markdown
@@ -96,11 +96,19 @@ The disk that serves PostgreSQL (/var/cfengine/state/pg) should be able to perfo
 
 ### Open file descriptors
 
-The policy server should ideally be able to accept connections from all clients; i.e. to allow at least as many incoming connections as there are clients.
-The system limit for this is controlled by `ulimit -n`; so the parent process from which you bootstrap should, for a server with 5000 hosts, run `ulimit -n 5000` first.
-You should also add such a `ulimit -n` command to the script that implements `service cfengine3 start` (and `restart`).
-For very large numbers of clients, it may be advantageous to build a custom kernel to allow setting `ulimit -n` high enough.
-You should also amend the value of `maxconnections` set in `cf_serverd.cf` under `/var/cfengine/masterfiles/controls/` to the number of clients, likewise.
+The policy server should ideally be able to accept connections from all
+clients; i.e. to allow at least as many incoming connections as there are
+clients.
+The system limit for this is controlled by `ulimit -n`; so the parent process
+from which you bootstrap should, for a server with 5000 hosts, run `ulimit -n
+5000` first.
+You should also add such a `ulimit -n` command to the script that implements
+`service cfengine3 start` (and `restart`) and to any policy that starts
+`cf-serverd` or `cf-hub`.
+For very large numbers of clients, it may be advantageous to build a custom
+kernel to allow setting `ulimit -n` high enough.
+You should also amend the value of `maxconnections` set in `cf_serverd.cf`
+under `/var/cfengine/masterfiles/controls/` to the number of clients, likewise.
 
 
 ### Memory


### PR DESCRIPTION
cf-hub and cf-serverd may be started or restarted from policy. So that they
are not relying on cf-execd to have been started with the proper ulimit they
should be updated as well.